### PR TITLE
Flesh out `TransmitQueue` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ uuid = { version = "0.7", features = ["serde", "v4"] }
 cuckoofilter = "0.3"
 indexmap = "1.0"
 rand = "0.6"
+bincode = "1.1"
 
 [dev-dependencies]
 tokio-test = { git = "https://github.com/LucioFranco/tokio", branch = "tokio-test" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cuckoofilter = "0.3"
 indexmap = "1.0"
 rand = "0.6"
 bincode = "1.1"
+rand = "0.6"
 
 [dev-dependencies]
 tokio-test = { git = "https://github.com/LucioFranco/tokio", branch = "tokio-test" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,3 @@ rand = "0.6"
 
 [dev-dependencies]
 tokio-test = { git = "https://github.com/LucioFranco/tokio", branch = "tokio-test" }
-quickcheck = "0.8"
-quickcheck_macros = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ rand = "0.6"
 [dev-dependencies]
 tokio-test = { git = "https://github.com/LucioFranco/tokio", branch = "tokio-test" }
 quickcheck = "0.8"
+quickcheck_macros = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ cuckoofilter = "0.3"
 indexmap = "1.0"
 rand = "0.6"
 bincode = "1.1"
-rand = "0.6"
 
 [dev-dependencies]
 tokio-test = { git = "https://github.com/LucioFranco/tokio", branch = "tokio-test" }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -206,11 +206,12 @@ impl TransmitQueue {
             for item in self.set.range(start..end) {
                 let size = serialized_size(&item.broadcast)? as i64;
                 if size as i64 > free {
+                    // Ignore this broadcast as it won't fit
                     continue;
                 }
 
                 // Update sizes
-                used += serialized_size(&item.broadcast)? as i64;
+                used += size;
                 free -= size;
 
                 broadcasts.push(item.clone());

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -109,6 +109,9 @@ pub struct TransmitQueue {
     gen: u64,
 }
 
+/// TransmitQueue is used to queue messages to broadcast to the cluster but limits the number of
+/// transmits per message. It prioritizes messages with lower transmit counts and newer version of
+/// the same message. This means that the items yielded by the queue will be ordered newest first.
 impl TransmitQueue {
     pub fn new() -> Self {
         Self {
@@ -118,15 +121,18 @@ impl TransmitQueue {
         }
     }
 
-    fn len(&self) -> usize {
+    /// Return the number of elements currently present in the queue.
+    pub fn len(&self) -> usize {
         self.set.len()
     }
 
+    /// Add the given `LimitedBroadcast` to the queue.
     fn add(&mut self, val: LimitedBroadcast) {
         self.filter.add(&val.broadcast.uuid);
         self.set.insert(val);
     }
 
+    /// Remove the given `LimitedBroadcast` from the queue.
     fn delete(&mut self, val: &LimitedBroadcast) {
         self.filter.delete(&val.broadcast.uuid);
         self.set.remove(&val);

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -183,7 +183,12 @@ impl TransmitQueue {
         let min = self.set.iter().next().unwrap_or(&min_item).transmits;
         let max = self.set.iter().next_back().unwrap_or(&max_item).transmits;
 
-        // Try to get all transmits within a given tier.
+        // Try to get all transmits within a given tier. We do this by getting the min and max
+        // number of transmits in the queue, and iterating over each transmit tier. Each iteration
+        // of this loop, we see if there are any broadcasts which fit the remaining size in the
+        // given transmit tier and add it to the `broadcasts` vec. These items are added to the
+        // prune list. If the item hasn't been transmitted `limit` (currently 5) times, it is
+        // reinserted into the queue.
         for transmits in min..max + 1 {
             let mut free: i64 = limit as i64 - used;
 
@@ -213,6 +218,9 @@ impl TransmitQueue {
 
                 // TODO: make this parameter configurable
                 if item.transmits + 1 <= 5 {
+                    // We reinsert after the broadcasts vec if filled as if we reinsert into the
+                    // queue here, the next iteration of the loop might consider the same item
+                    // again.
                     reinsert.push(item.clone())
                 }
             }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,17 +1,19 @@
 use std::cmp::Ordering;
 use std::collections::{hash_map::DefaultHasher, BTreeSet};
+use std::ops::Bound;
 
+use bincode::serialized_size;
 use cuckoofilter::CuckooFilter;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 // An empty struct for now.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Message {
     Joined,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Broadcast {
     uuid: Uuid,
     message: Message,
@@ -26,7 +28,7 @@ impl Broadcast {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq)]
 pub struct LimitedBroadcast {
     transmits: u64,
     id: u64,
@@ -41,12 +43,32 @@ pub struct LimitedBroadcast {
 impl Ord for LimitedBroadcast {
     fn cmp(&self, other: &LimitedBroadcast) -> Ordering {
         if self.transmits < other.transmits {
+            println!("Returning less");
             return Ordering::Less;
         } else if self.transmits > other.transmits {
+            println!("Returning greater");
             return Ordering::Greater;
         }
 
-        self.id.cmp(&other.id)
+        if self.id < other.id {
+            return Ordering::Less;
+        } else if self.id > other.id {
+            return Ordering::Greater;
+        }
+
+        Ordering::Equal
+    }
+}
+
+impl PartialEq for LimitedBroadcast {
+    fn eq(&self, other: &LimitedBroadcast) -> bool {
+        self.transmits == other.transmits && self.id == other.id
+    }
+}
+
+impl PartialEq<Broadcast> for LimitedBroadcast {
+    fn eq(&self, other: &Broadcast) -> bool {
+        self.broadcast.uuid == other.uuid
     }
 }
 
@@ -67,6 +89,14 @@ impl LimitedBroadcast {
 
     fn transmits(&self) -> u64 {
         self.transmits
+    }
+
+    fn gen(transmits: u64, id: u64, broadcast: Broadcast) -> Self {
+        Self {
+            transmits,
+            id,
+            broadcast,
+        }
     }
 }
 
@@ -113,8 +143,83 @@ impl TransmitQueue {
         self.set.insert(limited_broadcast);
     }
 
-    pub fn get_broadcasts(&mut self) -> Vec<&LimitedBroadcast> {
-        self.set.iter().collect()
+    pub fn get_broadcasts(&mut self, limit: u64) -> Vec<LimitedBroadcast> {
+        dbg!(limit);
+        let int_max = std::u64::MAX;
+        let mut used = 0;
+
+        let mut reinsert: Vec<LimitedBroadcast> = vec![];
+        let mut broadcasts: Vec<LimitedBroadcast> = vec![];
+
+        let joined = Broadcast::new(Message::Joined);
+
+        let min_item = LimitedBroadcast::gen(0, int_max, joined);
+        let max_item = LimitedBroadcast::gen(int_max, int_max, joined);
+
+        let min = dbg!(self.set.iter().next().unwrap_or(&min_item));
+        let max = dbg!(self.set.iter().next_back().unwrap_or(&max_item));
+
+        for i in min.transmits..max.transmits + 1 {
+            let free = limit - used;
+
+            dbg!((i, free));
+
+            if free <= 0 {
+                break;
+            }
+
+            let start = dbg!(LimitedBroadcast::gen(i, int_max, joined));
+            // Ranges in Rust are Include(min)..Exclude(max), so we need to add by one to get tier
+            // i
+            let end = dbg!(LimitedBroadcast::gen(i + 1, int_max, joined));
+
+            dbg!(&self.set);
+
+            let mut keep = None;
+
+            for item in self.set.range(start..end) {
+                dbg!(item);
+                if serialized_size(item).unwrap() > free {
+                    continue;
+                }
+                keep = Some(item.clone());
+                break;
+            }
+
+            if keep.is_none() {
+                continue;
+            }
+
+            let mut keep = keep.unwrap();
+
+            used += match serialized_size(&keep) {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("Error figuring out size: {}", e);
+                    0
+                }
+            };
+
+            broadcasts.push(keep.clone());
+
+            self.set.remove(&keep);
+            self.filter.delete(&keep.broadcast.uuid);
+
+            // TODO: Make limit depend on number of nodes
+            if keep.transmits + 1 > 5 {
+                // don't do anything since it's already been deleted.
+            } else {
+                keep.transmits += 1;
+                reinsert.push(keep);
+            }
+        }
+
+        for item in reinsert {
+            self.filter.add(&item.broadcast.uuid);
+            self.set.insert(item);
+        }
+
+        broadcasts
     }
 }
 
@@ -127,17 +232,20 @@ mod tests {
         let broadcast = Broadcast::new(Message::Joined);
         let clone = broadcast.clone();
 
+        let second = Broadcast::new(Message::Joined);
+
         let mut queue = TransmitQueue::new();
 
         queue.enqueue(broadcast);
+        queue.enqueue(second);
 
-        let broadcasts = queue.get_broadcasts();
+        let broadcasts = queue.get_broadcasts(1500);
 
         assert_eq!(broadcasts.len(), 1);
 
         queue.enqueue(clone);
 
-        let broadcasts = queue.get_broadcasts();
+        let broadcasts = queue.get_broadcasts(1500);
 
         assert_eq!(broadcasts.len(), 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,6 @@
 #[macro_use]
 extern crate tokio_test;
 
-// I really want to know a better way to do this.
-#[cfg(test)]
-extern crate quickcheck;
-#[cfg(test)]
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
-
 mod broadcast;
 mod node;
 mod peer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,13 @@
 #[macro_use]
 extern crate tokio_test;
 
+// I really want to know a better way to do this.
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
 mod broadcast;
 mod node;
 mod peer;


### PR DESCRIPTION
Adds the following methods:

* `len` : returns the number of items currently in the queue
* `add`: Adds the given `LimitedBroadcast` to the queue.
* `delete`: Removes the given `LimitedBroadcast` from the queue
* `get_broadcast`: Returns `Vec<LimitedBroadcast` limited by the size of each `Broadcast` specified to by the `limit` parameter. This method returns newer messages first and removes broadcasts which have been transmitted 5 times.