### PR TITLE
Add clique-grpc and grpc impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ authors = [
 edition = "2018"
 publish = false
 
+[workspace]
+members = ["clique-grpc"]
+
 [dependencies]
 bytes = "0.4"
 futures = { version = "=0.3.0-alpha.16", package = "futures-preview", features = ["async-await", "nightly", "io-compat", "compat"] }

--- a/clique-grpc/Cargo.toml
+++ b/clique-grpc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "clique-grpc"
+version = "0.1.0"
+authors = ["Lucio Franco <luciofranco14@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+clique = { path = ".." }
+bytes = "0.4"
+futures03 = { version = "=0.3.0-alpha.16", package = "futures-preview", features = ["async-await", "nightly", "io-compat", "compat"] }
+futures = { version = "0.1", package = "futures" } 
+tower-grpc = { version = "0.1", features = ["tower-hyper"] }
+tower-hyper = "0.1"
+tokio-tcp = "0.1"
+tower = "0.1"
+hyper = "0.12"
+tokio-sync = { git = "https://github.com/tokio-rs/tokio", features = ["async-traits"] }
+tokio-executor = "0.1"
+prost = "0.5"
+pin-utils = "0.1.0-alpha.4"
+
+[build-dependencies]
+tower-grpc-build = { version = "0.1",  features = ["tower-hyper"]  }

--- a/clique-grpc/build.rs
+++ b/clique-grpc/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    tower_grpc_build::Config::new()
+        .enable_server(true)
+        .enable_client(true)
+        .build(&["proto/clique.proto"], &["proto/"])
+        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+}

--- a/clique-grpc/proto/clique.proto
+++ b/clique-grpc/proto/clique.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package clique;
+
+service MembershipService {
+  rpc sendRequest (Request) returns (Response) {}
+}
+
+message Request
+{
+}
+
+message Response
+{
+}

--- a/clique-grpc/src/client.rs
+++ b/clique-grpc/src/client.rs
@@ -1,0 +1,30 @@
+use crate::proto::client;
+use clique::transport::{Client, Request, Response};
+use futures::Future as Future01;
+use futures03::compat::Future01CompatExt;
+use hyper::client::connect::HttpConnector;
+use std::future::Future;
+
+pub struct GrpcClient {
+    inner: client::MembershipService<tower_hyper::Client<HttpConnector, tower_grpc::BoxBody>>,
+}
+
+impl Client for GrpcClient {
+    type Error = crate::Error;
+    type Future = Box<dyn Future<Output = Result<Response, Self::Error>> + Unpin>;
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let req = tower_grpc::Request::new(req.into_inner().into());
+
+        // TODO: destination
+
+        let fut = self
+            .inner
+            .send_request(req)
+            .map(|res| res.into_inner().into())
+            .map_err(|_| crate::Error::Unknown)
+            .compat();
+
+        Box::new(fut)
+    }
+}

--- a/clique-grpc/src/lib.rs
+++ b/clique-grpc/src/lib.rs
@@ -1,0 +1,51 @@
+use clique::transport::{proto::RequestKind, Response};
+use std::{error, fmt};
+
+mod proto {
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/clique.rs"));
+}
+
+mod client;
+mod server;
+
+pub use client::GrpcClient;
+pub use server::GrpcServer;
+
+#[derive(Debug)]
+// TODO: add actual errors here!
+pub enum Error {
+    Unknown,
+}
+
+impl From<Response> for proto::Response {
+    fn from(_r: Response) -> Self {
+        unimplemented!()
+    }
+}
+
+impl From<proto::Request> for RequestKind {
+    fn from(_r: proto::Request) -> Self {
+        unimplemented!()
+    }
+}
+
+impl From<RequestKind> for proto::Request {
+    fn from(_r: RequestKind) -> Self {
+        unimplemented!()
+    }
+}
+
+impl From<proto::Response> for Response {
+    fn from(_r: proto::Response) -> Self {
+        unimplemented!()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl error::Error for Error {}

--- a/clique-grpc/src/server.rs
+++ b/clique-grpc/src/server.rs
@@ -1,0 +1,137 @@
+use crate::{
+    proto::{self, server},
+    Error,
+};
+use clique::transport::{Request, Server};
+use futures::sync::oneshot as oneshot01;
+use futures::{Future as Future01, Stream as Stream01};
+use futures03::{future, TryFutureExt};
+use std::net::SocketAddr;
+use tokio_sync::{mpsc, oneshot};
+use tokio_tcp::TcpListener;
+use tower_grpc::{Code, Status};
+use tower_hyper::server::Http;
+
+pub struct GrpcServer {
+    msg_rx: Option<mpsc::Receiver<Result<Request, Error>>>,
+    target_tx: Option<oneshot01::Sender<SocketAddr>>,
+}
+
+#[derive(Clone)]
+pub struct Svc {
+    msg_tx: mpsc::Sender<Result<Request, Error>>,
+}
+
+pub struct Background {
+    inner: Option<Svc>,
+    target_rx: oneshot01::Receiver<SocketAddr>,
+    state: State,
+}
+
+enum State {
+    Waiting,
+    Running(Box<dyn Future01<Item = (), Error = ()> + Send>),
+}
+
+impl GrpcServer {
+    pub fn new() -> (Self, Background) {
+        let (msg_tx, msg_rx) = mpsc::channel(100);
+        let (target_tx, target_rx) = oneshot01::channel();
+
+        let server = GrpcServer {
+            msg_rx: Some(msg_rx),
+            target_tx: Some(target_tx),
+        };
+        let svc = Svc { msg_tx };
+
+        let bg = Background {
+            inner: Some(svc),
+            target_rx,
+            state: State::Waiting,
+        };
+
+        (server, bg)
+    }
+}
+
+impl Server<SocketAddr> for GrpcServer {
+    type Error = Error;
+    type Stream = mpsc::Receiver<Result<Request, Self::Error>>;
+    type Future = future::Ready<Result<Self::Stream, Self::Error>>;
+
+    fn start(&mut self, target: SocketAddr) -> Self::Future {
+        let tx = self.msg_rx.take().expect("called start twice");
+        self.target_tx.take().unwrap().send(target).unwrap();
+
+        future::ready(Ok(tx))
+    }
+}
+
+impl server::MembershipService for Svc {
+    type SendRequestFuture = Box<
+        dyn Future01<Item = tower_grpc::Response<proto::Response>, Error = tower_grpc::Status>
+            + Send,
+    >;
+
+    fn send_request(
+        &mut self,
+        request: tower_grpc::Request<proto::Request>,
+    ) -> Self::SendRequestFuture {
+        let inbound_req = request.into_inner();
+        let (res_tx, res_rx) = oneshot::channel();
+        let req = Request::new(res_tx, inbound_req.into());
+
+        // TODO: poll_ready first find way to
+        self.msg_tx.try_send(Ok(req)).unwrap();
+
+        Box::new(
+            res_rx
+                .compat()
+                .map(|r| tower_grpc::Response::new(r.unwrap().into()))
+                .map_err(|_| Status::new(Code::Unknown, "Unknown grpc error")),
+        )
+    }
+}
+
+impl Future01 for Background {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> futures::Poll<(), ()> {
+        loop {
+            match &mut self.state {
+                State::Waiting => {
+                    let target = futures::try_ready!(self.target_rx.poll().map_err(|_| ()));
+
+                    let svc = self.inner.take().expect("Started server twice.");
+
+                    let svc = server::MembershipServiceServer::new(svc);
+                    let mut server = tower_hyper::Server::new(svc);
+
+                    let http = Http::new().http2_only(true).clone();
+
+                    let bind = TcpListener::bind(&target).expect("bind");
+
+                    let server = bind
+                        .incoming()
+                        .for_each(move |sock| {
+                            if let Err(e) = sock.set_nodelay(true) {
+                                return Err(e);
+                            }
+
+                            let serve = server.serve_with(sock, http.clone());
+                            tokio_executor::spawn(serve.map_err(|_| ()));
+
+                            Ok(())
+                        })
+                        .map_err(|e| eprintln!("accept error: {}", e));
+
+                    self.state = State::Running(Box::new(server));
+                    continue;
+                }
+
+                State::Running(fut) => return fut.poll(),
+            }
+        }
+    }
+}

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -31,7 +31,7 @@ pub struct Handle {
 
 impl<S, C, T> Cluster<S, C, T>
 where
-    S: Server<T, C>,
+    S: Server<T>,
     C: Client + Clone,
     T: Clone,
 {
@@ -57,7 +57,7 @@ where
     pub async fn start(self) -> Result<()> {
         let Cluster {
             mut membership,
-            server,
+            mut server,
             client,
             listen_target,
             event_tx,

--- a/src/transport/proto.rs
+++ b/src/transport/proto.rs
@@ -10,20 +10,24 @@ pub type RingNumber = i32;
 pub type Endpoint = String;
 
 /// Represents the NodeId internall it is just a Uuid v4
+#[derive(Debug)]
 pub struct NodeId(Uuid);
 
+#[derive(Debug)]
 pub enum RequestKind {
     PreJoin(PreJoinMessage),
     Join(JoinMessage),
     Probe,
 }
 
+#[derive(Debug)]
 pub enum ResponseKind {
     Join(JoinResponse),
     Response,
     Probe,
 }
 
+#[derive(Debug)]
 pub struct PreJoinMessage {
     pub sender: Endpoint,
     pub node_id: NodeId,
@@ -31,6 +35,7 @@ pub struct PreJoinMessage {
     pub config_id: ConfigId,
 }
 
+#[derive(Debug)]
 pub struct JoinMessage {
     pub sender: Endpoint,
     pub node_id: NodeId,
@@ -38,6 +43,7 @@ pub struct JoinMessage {
     pub config_id: ConfigId,
 }
 
+#[derive(Debug)]
 pub struct JoinResponse {
     pub sender: Endpoint,
     pub status: JoinStatus,
@@ -47,6 +53,7 @@ pub struct JoinResponse {
     pub cluster_metadata: HashMap<String, Metadata>,
 }
 
+#[derive(Debug)]
 pub enum JoinStatus {
     HostnameAlreadyInRing,
     NodeIdAlreadyInRing,
@@ -55,6 +62,7 @@ pub enum JoinStatus {
     MembershipRejected,
 }
 
+#[derive(Debug)]
 pub struct Metadata {
     pub metadata: HashMap<String, Bytes>,
 }


### PR DESCRIPTION
This PR adds a grpc implementation for `clique::transport::{Server, Client}`.