### PR TITLE
Clean up cluster and add builder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
 - template: ci/azure-rustfmt.yml
   parameters:
     name: rustfmt
-    rust_version: nightly-2019-07-09
+    rust_version: beta
 
 - job: test
   displayName: Test

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+beta

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,16 +1,52 @@
-use crate::{cluster::Cluster, error::Result, transport::Transport};
+use crate::{
+    cluster::Cluster, cluster::Inner, error::Result, event::Event, handle::Handle,
+    transport::Transport,
+};
 use std::marker::PhantomData;
+
+use tokio_sync::watch;
 
 #[derive(Debug, Clone)]
 pub struct Builder<T, Target> {
-    _pd: PhantomData<(T, Target)>,
+    transport: Option<T>,
+    target: Option<Target>,
 }
 
 impl<T, Target> Builder<T, Target>
 where
-    T: Transport<Target>,
+    T: Transport<Target> + Send,
+    Target: Send + Clone + Into<String>,
 {
-    pub fn finish(self) -> Result<Cluster<T, Target>> {
-        unimplemented!()
+    pub fn new() -> Self {
+        Builder {
+            transport: None,
+            target: None,
+        }
+    }
+
+    pub async fn finish(mut self) -> Cluster<T, Target> {
+        let (event_tx, event_rx) = watch::channel(Event::new());
+        let transport = self
+            .transport
+            .take()
+            .unwrap_or_else(|| panic!("Unable to get trasnport"));
+        let target = self
+            .target
+            .take()
+            .unwrap_or_else(|| panic!("Unable to get target"));
+        let inner = Inner::new(transport, target, event_tx).await;
+        let handle = Handle::new(event_rx);
+
+        Cluster::new(handle, inner)
+    }
+
+    pub fn transport(mut self, transport: T) -> Self {
+        self.transport = Some(transport);
+        self
+    }
+
+    pub fn target(mut self, target: Target) -> Self {
+        self.target = Some(target);
+        self
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,8 +1,7 @@
 use crate::{
-    cluster::Cluster, cluster::Inner, error::Result, event::Event, handle::Handle,
+    cluster::Cluster, cluster::Inner, event::Event, handle::Handle,
     transport::Transport,
 };
-use std::marker::PhantomData;
 
 use tokio_sync::watch;
 
@@ -48,5 +47,5 @@ where
     pub fn target(mut self, target: Target) -> Self {
         self.target = Some(target);
         self
-    }
+}
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,2 +1,8 @@
 #[derive(Debug, PartialEq, Clone)]
 pub struct Event;
+
+impl Event {
+    pub fn new() -> Self {
+        Event
+    }
+}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -11,6 +11,12 @@ pub struct Handle {
     event_rx: watch::Receiver<Event>,
 }
 
+impl Handle {
+    pub fn new(event_rx: watch::Receiver<Event>) -> Self {
+        Handle { event_rx }
+    }
+}
+
 impl Stream for Handle {
     type Item = Event;
 


### PR DESCRIPTION
Clean up cluster to remove the unnecessary state enum and flesh out builder.